### PR TITLE
fix: support user inputted arch by passing in env var (ENT-53)

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
 env:
   NULLIFY_VERSION: 0.0.0
+  NULLIFY_ARCH: linux_amd64  # New environment variable
 jobs:
   build:
     name: Build, Test and Format
@@ -14,7 +15,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Nullify CLI
         run: |
-          wget -q https://github.com/Nullify-Platform/cli/releases/download/v${{ env.NULLIFY_VERSION }}/nullify_linux_amd64_${{ env.NULLIFY_VERSION }} -O nullify
+          download_url="https://github.com/Nullify-Platform/cli/releases/download/v${{ env.NULLIFY_VERSION }}/nullify_${{ env.NULLIFY_ARCH }}_${{ env.NULLIFY_VERSION }}"
+          wget -q $download_url -O nullify
           chmod +x nullify
       - name: Test Nullify CLI
         run: |


### PR DESCRIPTION
## Description

Supports different arch for ci-build by using the runner env var.

## Test Plan

Run the action with using a different `NULLIFY_ARCH` env var, e.g. `linux_arm64`. Assert action works as expected.

## Linked Issues & PRs

- resolves <insert-issue-link>
- relates to <insert-pr-link>

[GitHub Issue Linking Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
