### PR TITLE
fix: add support for image-label input (ENT-58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The [Nullify DAST](https://docs.nullify.ai/features/api-scanning) GitHub Action 
 | nullify-version   | Version of the Nullify CLI to use                                                                | `false`  | 0.10.12                  |
 | header            | Header to include in all requests to your app for authorization                                  | `false`  |                          |
 | local             | Run the scan from the GitHub action instead of on Nullify Cloud                                  | `false`  | false                    |
+| image-label       | Label to identify the Docker image being tested                                               | `false`  |                          |
 
 Often the `target-host` is a staging environment in a private network.
 In this case, deploy a GitHub Action runner in the same private network then set `local: 'true'` to run the scan from the GitHub action.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The [Nullify DAST](https://docs.nullify.ai/features/api-scanning) GitHub Action 
 | nullify-version   | Version of the Nullify CLI to use                                                                | `false`  | 0.10.12                  |
 | header            | Header to include in all requests to your app for authorization                                  | `false`  |                          |
 | local             | Run the scan from the GitHub action instead of on Nullify Cloud                                  | `false`  | false                    |
-| image-label       | Label to identify the Docker image being tested                                               | `false`  |                          |
+| image-label       | Label to identify the Docker image being tested                                                  | `false`  |                          |
 
 Often the `target-host` is a staging environment in a private network.
 In this case, deploy a GitHub Action runner in the same private network then set `local: 'true'` to run the scan from the GitHub action.

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,9 @@ inputs:
     description: Nullify dynamic analysis scan run locally
     required: false
     default: 'false'
+  image-label:
+    description: Label to identify the Docker image to use for the scan
+    required: false
 runs:
   using: "composite"
   steps:
@@ -72,7 +75,8 @@ runs:
             --target-host "${{ inputs.target-host }}" \
             --github-owner "$repo_owner" \
             --github-repo "$repo_name" \
-            --header "${{ inputs.header }}"
+            --header "${{ inputs.header }}" \
+            ${{ inputs.image-label != '' && format('--image-label "{0}"', inputs.image-label) || '' }}
     - name: Execute Nullify DAST
       if: ${{ inputs.local != 'true' }}
       shell: sh
@@ -91,4 +95,5 @@ runs:
             --target-host "${{ inputs.target-host }}" \
             --github-owner "$repo_owner" \
             --github-repo "$repo_name" \
-            --header "${{ inputs.header }}"
+            --header "${{ inputs.header }}" \
+            ${{ inputs.image-label != '' && format('--image-label "{0}"', inputs.image-label) || '' }}


### PR DESCRIPTION
## Description

This PR adds support for `--image-label` input for running DAST scans, in line with our CLI tool: https://github.com/nullify-Platform/cli

## Test Plan

Run a GitHub action with the `--image-label` input and assert it runs as expected.

E.g..
```
- name: Run Nullify vulnerability scanner
  uses: nullify-platform/dast-action@main
  with:
    app-name: 'My REST API'
    header: 'Authorization: Bearer 1234'
    spec-path: 'openapi.json'
    target-host: 'api.myapp1234.dev'
    image-label: 'my-docker-image:latest'
```

## Linked Issues & PRs

- resolves <insert-issue-link>
- relates to <insert-pr-link>

[GitHub Issue Linking Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
