### PR TITLE
docs: refresh workflow examples to ubuntu-latest and checkout@v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ on:
 jobs:
   nullify-dast:
     name: Nullify DAST
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run Nullify vulnerability scanner
         uses: nullify-platform/dast-action@main
         with:
@@ -122,10 +122,10 @@ on:
 jobs:
   nullify-dast:
     name: Nullify DAST with Basic Auth
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run Nullify vulnerability scanner
         uses: nullify-platform/dast-action@main
         with:
@@ -148,10 +148,10 @@ on:
 jobs:
   nullify-dast:
     name: Nullify DAST with OAuth2
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run Nullify vulnerability scanner
         uses: nullify-platform/dast-action@main
         with:
@@ -175,10 +175,10 @@ on:
 jobs:
   nullify-dast:
     name: Nullify DAST with Session Auth
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run Nullify vulnerability scanner
         uses: nullify-platform/dast-action@main
         with:
@@ -207,10 +207,10 @@ on:
 jobs:
   nullify-dast:
     name: Nullify DAST
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run Nullify vulnerability scanner
         uses: nullify-platform/dast-action@main
         with:
@@ -236,10 +236,10 @@ on:
 jobs:
   nullify-dast:
     name: Nullify DAST with Role-Based Access Control Testing
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run Nullify vulnerability scanner
         uses: nullify-platform/dast-action@main
         with:


### PR DESCRIPTION
![Claude](https://img.shields.io/badge/Claude-Anthropic-blueviolet?logo=anthropic)

## Summary

The README workflow examples use `runs-on: ubuntu-20.04` (runner image is end-of-life) and `actions/checkout@v2` (two majors behind). This updates all six example blocks to `ubuntu-latest` and `actions/checkout@v4` so users copying them get workflows that run on current GitHub-hosted runners.

Docs-only; no action code changed.

Found during a `public-docs` accuracy audit in the main monorepo (`Nullify-Platform/nullify` PR #7994); split out here because `dast-action` is a separate repo / submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)